### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds a `.github/dependabot.yml` that checks for GitHub Actions updates weekly, grouped into a single PR.